### PR TITLE
Fix javadoc warning

### DIFF
--- a/src/main/java/org/glassfish/annotation/processing/logging/BaseLoggingProcessor.java
+++ b/src/main/java/org/glassfish/annotation/processing/logging/BaseLoggingProcessor.java
@@ -70,7 +70,6 @@ public abstract class BaseLoggingProcessor extends AbstractProcessor {
      * from the existing resource bundle file.
      * 
      * @param rbName the package the resource bundle is relative
-     * @return a LogResourceBundle
      */
     protected void loadLogMessages(LoggingMetadata lrb, String rbName) {
     


### PR DESCRIPTION
```
[WARNING] src/main/java/org/glassfish/annotation/processing/logging/BaseLoggingProcessor.java:75: warning - @return tag cannot be used in method with void return type.
```