### PR TITLE
Module info to support JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,16 @@
                 <version>3.13.0</version>
                 <configuration>
                     <release>17</release>
-                    <compilerArgument>-proc:none</compilerArgument>                    
-                </configuration>                                
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * @author David Matejcek
+ */
+module org.glassfish.annotation.processing.logging {
+
+    requires java.base;
+    requires java.compiler;
+    requires java.logging;
+
+    exports org.glassfish.logging.annotation;
+}


### PR DESCRIPTION
* Tested with GlassFish 7.0.19-SNAPSHOT
* Required to use these annotations in Glassfish code when GlassFish would use JPMS correctly.
